### PR TITLE
Replace requests.Session with dlt requests.Client for automatic retry and rate limiting

### DIFF
--- a/src/estat_api_dlt_helper/api/client.py
+++ b/src/estat_api_dlt_helper/api/client.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Generator, Optional
 
-import requests
+from dlt.sources.helpers.requests.retry import Client
+from requests import Response
 
 from ..utils.logging import get_logger
 from .endpoints import ESTAT_ENDPOINTS
@@ -13,12 +14,14 @@ class EstatApiClient:
 
     Provides methods to fetch statistical data from Japan's e-Stat API.
     Handles API authentication, request formatting, and response parsing.
+    Uses dlt's requests Client for automatic retry, rate limiting, and
+    connection pooling.
 
     Attributes:
         app_id: e-Stat API application ID for authentication.
         base_url: Base URL for API endpoints.
         timeout: Request timeout in seconds.
-        session: HTTP session for connection pooling.
+        client: HTTP client with retry and connection pooling.
     """
 
     def __init__(
@@ -37,12 +40,12 @@ class EstatApiClient:
         self.app_id = app_id
         self.base_url = base_url or ESTAT_ENDPOINTS["base_url"]
         self.timeout = timeout
-        self.session = requests.Session()
-        self.session.headers.update({"accept": "application/json"})
+        self.client = Client(request_timeout=timeout)
+        self.default_headers = {"accept": "application/json"}
 
     def _make_request(
         self, endpoint: str, params: Dict[str, Any], **kwargs: Any
-    ) -> requests.Response:
+    ) -> Response:
         """Make HTTP request to e-Stat API.
 
         Args:
@@ -60,9 +63,10 @@ class EstatApiClient:
 
         logger.debug(f"Making request to {url} with params: {params}")
 
-        response = self.session.get(url, params=params, timeout=self.timeout, **kwargs)
+        response = self.client.get(
+            url, params=params, headers=self.default_headers, **kwargs
+        )
 
-        response.raise_for_status()
         return response
 
     def get_stats_data(
@@ -190,5 +194,5 @@ class EstatApiClient:
         return response.json()
 
     def close(self) -> None:
-        """Close the session."""
-        self.session.close()
+        """Close the underlying HTTP session."""
+        self.client.session.close()

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -1,11 +1,20 @@
 from unittest.mock import Mock, patch
 
+import pytest
+
 from estat_api_dlt_helper.api.client import EstatApiClient
 from estat_api_dlt_helper.api.endpoints import ESTAT_ENDPOINTS
 
 
 class TestEstatApiClient:
     """Test cases for EstatApiClient"""
+
+    @pytest.fixture(autouse=True)
+    def mock_client(self):
+        with patch("estat_api_dlt_helper.api.client.Client") as mock_cls:
+            self.mock_client_cls = mock_cls
+            self.mock_client = mock_cls.return_value
+            yield
 
     def test_init(self):
         """Test client initialization"""
@@ -14,7 +23,8 @@ class TestEstatApiClient:
         assert client.app_id == "test_app_id"
         assert client.base_url == ESTAT_ENDPOINTS["base_url"]
         assert client.timeout == 60
-        assert client.session is not None
+        assert client.client is not None
+        self.mock_client_cls.assert_called_once_with(request_timeout=60)
 
     def test_init_with_custom_params(self):
         """Test client initialization with custom parameters"""
@@ -28,26 +38,23 @@ class TestEstatApiClient:
         assert client.base_url == custom_url
         assert client.timeout == custom_timeout
 
-    @patch("requests.Session.get")
-    def test_make_request_success(self, mock_get):
+    def test_make_request_success(self):
         """Test successful API request"""
         mock_response = Mock()
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        self.mock_client.get.return_value = mock_response
 
         client = EstatApiClient(app_id="test_app_id")
         response = client._make_request("test_endpoint", {"param1": "value1"})
 
         assert response == mock_response
-        mock_get.assert_called_once()
+        self.mock_client.get.assert_called_once()
 
         # Check that appId was added to params
-        call_args = mock_get.call_args
+        call_args = self.mock_client.get.call_args
         assert call_args[1]["params"]["appId"] == "test_app_id"
         assert call_args[1]["params"]["param1"] == "value1"
 
-    @patch("requests.Session.get")
-    def test_get_stats_data_success(self, mock_get):
+    def test_get_stats_data_success(self):
         """Test successful statistics data retrieval"""
         # Mock response data
         mock_response_data = {
@@ -75,30 +82,27 @@ class TestEstatApiClient:
 
         mock_response = Mock()
         mock_response.json.return_value = mock_response_data
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        self.mock_client.get.return_value = mock_response
 
         client = EstatApiClient(app_id="test_app_id")
         result = client.get_stats_data(stats_data_id="0000020202")
 
         assert result == mock_response_data
-        mock_get.assert_called_once()
+        self.mock_client.get.assert_called_once()
 
         # Verify default parameters
-        call_args = mock_get.call_args
+        call_args = self.mock_client.get.call_args
         params = call_args[1]["params"]
         assert params["statsDataId"] == "0000020202"
         assert params["startPosition"] == 1
         assert params["limit"] == 100000
         assert params["metaGetFlg"] == "Y"
 
-    @patch("requests.Session.get")
-    def test_get_stats_data_with_custom_params(self, mock_get):
+    def test_get_stats_data_with_custom_params(self):
         """Test statistics data retrieval with custom parameters"""
         mock_response = Mock()
         mock_response.json.return_value = {"test": "data"}
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        self.mock_client.get.return_value = mock_response
 
         client = EstatApiClient(app_id="test_app_id")
         client.get_stats_data(
@@ -109,15 +113,14 @@ class TestEstatApiClient:
             cdCat01="001",  # additional parameter
         )
 
-        call_args = mock_get.call_args
+        call_args = self.mock_client.get.call_args
         params = call_args[1]["params"]
         assert params["startPosition"] == 10
         assert params["limit"] == 1000
         assert params["metaGetFlg"] == "N"
         assert params["cdCat01"] == "001"
 
-    @patch("requests.Session.get")
-    def test_get_stats_data_generator(self, mock_get):
+    def test_get_stats_data_generator(self):
         """Test statistics data generator for pagination"""
         # Mock first page response
         first_response_data = {
@@ -147,13 +150,11 @@ class TestEstatApiClient:
 
         mock_response1 = Mock()
         mock_response1.json.return_value = first_response_data
-        mock_response1.raise_for_status.return_value = None
 
         mock_response2 = Mock()
         mock_response2.json.return_value = second_response_data
-        mock_response2.raise_for_status.return_value = None
 
-        mock_get.side_effect = [mock_response1, mock_response2]
+        self.mock_client.get.side_effect = [mock_response1, mock_response2]
 
         client = EstatApiClient(app_id="test_app_id")
         pages = list(
@@ -165,10 +166,9 @@ class TestEstatApiClient:
         assert len(pages) == 2
         assert pages[0] == first_response_data
         assert pages[1] == second_response_data
-        assert mock_get.call_count == 2
+        assert self.mock_client.get.call_count == 2
 
-    @patch("requests.Session.get")
-    def test_get_stats_list(self, mock_get):
+    def test_get_stats_list(self):
         """Test statistics list retrieval"""
         mock_response_data = {
             "GET_STATS_LIST": {
@@ -182,32 +182,30 @@ class TestEstatApiClient:
 
         mock_response = Mock()
         mock_response.json.return_value = mock_response_data
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        self.mock_client.get.return_value = mock_response
 
         client = EstatApiClient(app_id="test_app_id")
         result = client.get_stats_list(search_word="人口")
 
         assert result == mock_response_data
 
-        call_args = mock_get.call_args
+        call_args = self.mock_client.get.call_args
         params = call_args[1]["params"]
         assert params["searchWord"] == "人口"
 
     def test_close(self):
         """Test session closing"""
-        client = EstatApiClient(app_id="test_app_id")
+        mock_session = Mock()
+        self.mock_client.session = mock_session
 
-        with patch.object(client.session, "close") as mock_close:
-            client.close()
-            mock_close.assert_called_once()
+        client = EstatApiClient(app_id="test_app_id")
+        client.close()
+        mock_session.close.assert_called_once()
 
 
 def test_api_client_integration():
     """Integration test with sample parameters (requires actual API key)"""
     import os
-
-    import pytest
 
     api_key = os.getenv("ESTAT_API_KEY")
     if not api_key:


### PR DESCRIPTION
## Description

EstatApiClient の HTTP クライアントを `requests.Session` から dlt の `requests.Client` に置き換え、自動リトライ（5回/指数バックオフ）、レート制限（429 + Retry-After 対応）、接続プーリングを得る。

変更内容:
- `import requests` → `from dlt.sources.helpers.requests.retry import Client`
- `requests.Session()` → `Client(request_timeout=timeout)`
- `raise_for_status()` 削除（Client がデフォルトで実行）
- テストのモックパスを Client ベースに更新

## Ref

https://dlthub.com/docs/general-usage/http/requests

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally (`uv run pytest`)
- [x] I have run linting (`uv run ruff check src/`)
- [x] I have run type checking (`uv run pyright src`)