### PR TITLE
Add type annotations for create_estat_pipeline and create_estat_resource functions

### DIFF
--- a/src/estat_api_dlt_helper/loader/dlt_pipeline.py
+++ b/src/estat_api_dlt_helper/loader/dlt_pipeline.py
@@ -47,7 +47,7 @@ def create_estat_pipeline(
         **pipeline_kwargs: Additional keyword arguments for dlt.pipeline
 
     Returns:
-        dlt.Pipeline: Configured DLT pipeline
+        Pipeline: Configured DLT pipeline
 
     Example:
         ```python

--- a/src/estat_api_dlt_helper/loader/dlt_resource.py
+++ b/src/estat_api_dlt_helper/loader/dlt_resource.py
@@ -133,7 +133,7 @@ def create_estat_resource(
         **resource_kwargs: Additional keyword arguments for dlt.resource
 
     Returns:
-        dlt.Resource: Configured DLT resource for e-Stat API data
+        DltResource: Configured DLT resource for e-Stat API data
 
     Example:
         ```python


### PR DESCRIPTION
## Description

`create_estat_pipeline` と `create_estat_resource` の返り値の型アノテーションを `Any` から具体的な型に変更。

- `create_estat_pipeline`: `Any` → `Pipeline` (`dlt.pipeline.pipeline.Pipeline`)
- `create_estat_resource`: `Any` → `DltResource` (`dlt.extract.resource.DltResource`)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally (`uv run pytest`)
- [x] I have run linting (`uv run ruff check src/`)
- [x] I have run type checking (`uv run pyright src`)
