### PR TITLE
estat_source の tables モードで app_id 等の設定を各テーブルに伝播 

### DIFF
--- a/src/estat_api_dlt_helper/loader/estat_source.py
+++ b/src/estat_api_dlt_helper/loader/estat_source.py
@@ -158,12 +158,15 @@ def estat_source(
                 f"Remove these arguments or configure them on each estat_table() call."
             )
         for table in tables:
-            table.bind(
-                app_id=app_id,
-                limit=limit,
-                maximum_offset=maximum_offset,
-                timeout=timeout,
-            )
+            table_explicit = getattr(table, "_table_explicit_args", set())
+            bind_kwargs: Dict[str, Any] = {"app_id": app_id}
+            if "limit" not in table_explicit:
+                bind_kwargs["limit"] = limit
+            if "maximum_offset" not in table_explicit:
+                bind_kwargs["maximum_offset"] = maximum_offset
+            if "timeout" not in table_explicit:
+                bind_kwargs["timeout"] = timeout
+            table.bind(**bind_kwargs)
             yield table
         return
 

--- a/src/estat_api_dlt_helper/loader/estat_source.py
+++ b/src/estat_api_dlt_helper/loader/estat_source.py
@@ -71,8 +71,10 @@ def estat_source(
             - List[str]: multiple IDs (resource names: "estat_{id}")
             - Dict[str, str]: {resource_name: stats_data_id} for custom names
         tables: Pre-configured DltResource list (from estat_table).
-            When provided, write_disposition/primary_key/app_id are ignored
+            When provided, write_disposition/primary_key are ignored
             as each resource carries its own settings.
+            app_id/limit/maximum_offset/timeout are propagated to each
+            table via bind().
         app_id: e-Stat API application ID. Resolved automatically from
             secrets.toml ([sources.estat] app_id) or environment variable
             (SOURCES__ESTAT__APP_ID) if not provided.
@@ -155,7 +157,14 @@ def estat_source(
                 f"{', '.join(found)}. "
                 f"Remove these arguments or configure them on each estat_table() call."
             )
-        yield from tables
+        for table in tables:
+            table.bind(
+                app_id=app_id,
+                limit=limit,
+                maximum_offset=maximum_offset,
+                timeout=timeout,
+            )
+            yield table
         return
 
     assert stats_data_ids is not None  # guaranteed by validation above

--- a/src/estat_api_dlt_helper/loader/estat_table.py
+++ b/src/estat_api_dlt_helper/loader/estat_table.py
@@ -10,6 +10,7 @@ from dlt.sources import incremental as dlt_incremental
 from ..api.client import EstatApiClient
 from .dlt_resource import _fetch_estat_data
 
+_UNSET: Any = object()
 
 _DEFAULT_API_PARAMS: Dict[str, str] = {
     "lang": "J",
@@ -33,9 +34,9 @@ def estat_table(
     write_disposition: str = "replace",
     primary_key: Optional[Union[str, List[str]]] = None,
     incremental: Optional[dlt_incremental[str]] = None,
-    limit: int = 100000,
-    maximum_offset: Optional[int] = None,
-    timeout: int = 60,
+    limit: int = _UNSET,  # type: ignore[assignment]  # sentinel to detect explicit args
+    maximum_offset: Optional[int] = _UNSET,  # type: ignore[assignment]  # sentinel to detect explicit args
+    timeout: int = _UNSET,  # type: ignore[assignment]  # sentinel to detect explicit args
     **api_params: Any,
 ) -> DltResource:
     """Create a DLT resource for a single e-Stat statistical table.
@@ -85,6 +86,20 @@ def estat_table(
         pipeline.run(resource)
         ```
     """
+    _table_explicit_args: set[str] = set()
+    if limit is not _UNSET:
+        _table_explicit_args.add("limit")
+    else:
+        limit = 100000
+    if maximum_offset is not _UNSET:
+        _table_explicit_args.add("maximum_offset")
+    else:
+        maximum_offset = None
+    if timeout is not _UNSET:
+        _table_explicit_args.add("timeout")
+    else:
+        timeout = 60
+
     if not stats_data_id or not stats_data_id.strip():
         raise ValueError("stats_data_id must not be empty")
 
@@ -129,4 +144,5 @@ def estat_table(
         finally:
             client.close()
 
+    _estat_data._table_explicit_args = _table_explicit_args  # type: ignore[attr-defined]
     return _estat_data

--- a/src/estat_api_dlt_helper/loader/estat_table.py
+++ b/src/estat_api_dlt_helper/loader/estat_table.py
@@ -109,6 +109,9 @@ def estat_table(
     def _estat_data(
         app_id: str = app_id,
         time_incremental: Optional[dlt_incremental[str]] = incremental,
+        limit: int = limit,
+        maximum_offset: Optional[int] = maximum_offset,
+        timeout: int = timeout,
     ) -> Generator[pa.Table, None, None]:
         request_params = dict(params)
         if time_incremental is not None and time_incremental.start_value is not None:

--- a/tests/unit/test_estat_source.py
+++ b/tests/unit/test_estat_source.py
@@ -167,7 +167,7 @@ class TestEstatSource:
         assert source.resources["gdp"].write_disposition == "replace"
 
     def test_tables_app_id_propagated_from_source(self):
-        """tables モードで app_id を source にのみ設定すれば各 table に伝播される."""
+        """tables モードで source の app_id が各 table の app_id を上書きする."""
         source = estat_source(
             tables=[
                 estat_table(
@@ -186,7 +186,7 @@ class TestEstatSource:
         for resource in source.resources.values():
             assert resource.explicit_args.get("app_id") == "source_app_id"
 
-    def test_tables_limit_timeout_propagated_from_source(self):
+    def test_tables_limit_maximum_offset_timeout_propagated_from_source(self):
         """tables モードで limit/maximum_offset/timeout が source から伝播される."""
         source = estat_source(
             tables=[

--- a/tests/unit/test_estat_source.py
+++ b/tests/unit/test_estat_source.py
@@ -166,6 +166,46 @@ class TestEstatSource:
         assert source.resources["pop"].write_disposition == "merge"
         assert source.resources["gdp"].write_disposition == "replace"
 
+    def test_tables_app_id_propagated_from_source(self):
+        """tables モードで app_id を source にのみ設定すれば各 table に伝播される."""
+        source = estat_source(
+            tables=[
+                estat_table(
+                    stats_data_id="0000020201",
+                    app_id="placeholder",
+                    table_name="pop",
+                ),
+                estat_table(
+                    stats_data_id="0004028584",
+                    app_id="placeholder",
+                    table_name="gdp",
+                ),
+            ],
+            app_id="source_app_id",
+        )
+        for resource in source.resources.values():
+            assert resource.explicit_args.get("app_id") == "source_app_id"
+
+    def test_tables_limit_timeout_propagated_from_source(self):
+        """tables モードで limit/maximum_offset/timeout が source から伝播される."""
+        source = estat_source(
+            tables=[
+                estat_table(
+                    stats_data_id="0000020201",
+                    app_id="test_app_id",
+                    table_name="pop",
+                ),
+            ],
+            app_id="test_app_id",
+            limit=50000,
+            maximum_offset=200000,
+            timeout=120,
+        )
+        for resource in source.resources.values():
+            assert resource.explicit_args.get("limit") == 50000
+            assert resource.explicit_args.get("maximum_offset") == 200000
+            assert resource.explicit_args.get("timeout") == 120
+
     def test_tables_and_stats_data_ids_raises(self):
         with pytest.raises(ValueError, match="Cannot specify both"):
             estat_source(

--- a/tests/unit/test_estat_source.py
+++ b/tests/unit/test_estat_source.py
@@ -206,6 +206,70 @@ class TestEstatSource:
             assert resource.explicit_args.get("maximum_offset") == 200000
             assert resource.explicit_args.get("timeout") == 120
 
+    def test_tables_per_table_limit_preserved(self):
+        """tables モードで個別に設定した limit は source の bind で上書きされない."""
+        source = estat_source(
+            tables=[
+                estat_table(
+                    stats_data_id="0000020201",
+                    app_id="test_app_id",
+                    table_name="small",
+                    limit=500,
+                ),
+                estat_table(
+                    stats_data_id="0004028584",
+                    app_id="test_app_id",
+                    table_name="default",
+                ),
+            ],
+            app_id="test_app_id",
+            limit=100000,
+        )
+        # limit=500 を明示設定 → bind で上書きされない（explicit_args に含まれない）
+        assert "limit" not in source.resources["small"].explicit_args
+        # limit 未設定 → source の値が bind で伝播される
+        assert source.resources["default"].explicit_args.get("limit") == 100000
+
+    def test_tables_per_table_all_params_preserved(self):
+        """tables モードで個別に設定した limit/maximum_offset/timeout は bind で上書きされない."""
+        source = estat_source(
+            tables=[
+                estat_table(
+                    stats_data_id="0000020201",
+                    app_id="test_app_id",
+                    table_name="custom",
+                    limit=500,
+                    maximum_offset=1000,
+                    timeout=30,
+                ),
+            ],
+            app_id="source_app_id",
+            limit=100000,
+            maximum_offset=200000,
+            timeout=120,
+        )
+        resource = source.resources["custom"]
+        # app_id は常に source から伝播
+        assert resource.explicit_args.get("app_id") == "source_app_id"
+        # 個別設定した値は bind で上書きされない
+        assert "limit" not in resource.explicit_args
+        assert "maximum_offset" not in resource.explicit_args
+        assert "timeout" not in resource.explicit_args
+
+    def test_tables_pre_bound_resource_raises(self):
+        """tables モードで bind 済みの resource を渡すと TypeError になる."""
+        table = estat_table(
+            stats_data_id="0000020201",
+            app_id="test_app_id",
+            table_name="pop",
+        )
+        table.bind(app_id="pre_bound_app_id", limit=999)
+        with pytest.raises(TypeError, match="is not callable"):
+            estat_source(
+                tables=[table],
+                app_id="source_app_id",
+            )
+
     def test_tables_and_stats_data_ids_raises(self):
         with pytest.raises(ValueError, match="Cannot specify both"):
             estat_source(


### PR DESCRIPTION
## Description

`estat_source` の `tables` モードで、`app_id`/`limit`/`maximum_offset`/`timeout` を source レベルで指定すれば各 `estat_table` に自動伝播されるようにした。

従来は `tables` モードで `app_id` 等を source に渡しても無視され、各 `estat_table()` に個別指定が必要だった。
`DltResource.bind()` を使い、source レベルの値を各テーブルリソースに注入する。

```python
# Before: 各 table に app_id を個別指定する必要があった
source = estat_source(
    app_id=app_id,
    tables=[
        estat_table(stats_data_id="001", table_name="pop", app_id=app_id),
        estat_table(stats_data_id="002", table_name="gdp", app_id=app_id),
    ],
)

# After: source に指定すれば tables に伝播される
source = estat_source(
    app_id=app_id,
    timeout=120,
    tables=[
        estat_table(stats_data_id="001", table_name="pop"),
        estat_table(stats_data_id="002", table_name="gdp"),
    ],
)
```

変更内容:
- `estat_table`: 内部関数 `_estat_data` のパラメータに `limit`/`maximum_offset`/`timeout` を追加し、`bind()` で上書き可能にした
- `estat_source`: `tables` モードで `bind()` を使い `app_id`/`limit`/`maximum_offset`/`timeout` を各テーブルに伝播
- テスト追加: 伝播の動作確認

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally (`uv run pytest`)
- [x] I have run linting (`uv run ruff check src/`)
- [x] I have run type checking (`uv run pyright src`)
