### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/src/estat_api_dlt_helper/api/client.py
+++ b/src/estat_api_dlt_helper/api/client.py
@@ -60,8 +60,12 @@ class EstatApiClient:
 
         # Add appId to params
         params = {"appId": self.app_id, **params}
+        safe_params = {
+            key: ("***REDACTED***" if key == "appId" else value)
+            for key, value in params.items()
+        }
 
-        logger.debug(f"Making request to {url} with params: {params}")
+        logger.debug(f"Making request to {url} with params: {safe_params}")
 
         response = self.client.get(
             url, params=params, headers=self.default_headers, **kwargs


### PR DESCRIPTION
Potential fix for [https://github.com/K-Oxon/estat_api_dlt_helper/security/code-scanning/1](https://github.com/K-Oxon/estat_api_dlt_helper/security/code-scanning/1)

General fix approach: never log raw request parameters when they may contain credentials/tokens/secrets. Instead, log a sanitized copy where known sensitive keys are redacted.

Best fix here (without changing functionality): in `src/estat_api_dlt_helper/api/client.py`, inside `_make_request`, replace the current debug log of `params` with a redacted dict (`appId` masked). Keep request behavior unchanged; only adjust logging content. This addresses all reported variants because they all flow to the same sink line.

Needed changes:
- File: `src/estat_api_dlt_helper/api/client.py`
- Region: `_make_request` around current line 64
- Add local `safe_params` creation and log that instead of `params`
- No new dependency required, no import changes required


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
