### PR TITLE
[codex] Fix Pages artifact action pinning

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
         run: uv run mkdocs build
       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: ./site
   


### PR DESCRIPTION
## Summary
- update actions/upload-pages-artifact from the pinned v3 commit to the pinned v5 commit
- v3 internally calls actions/upload-artifact@v4, which is blocked by the repository SHA pinning policy
- v5 pins its internal upload-artifact action, so Pages deploy can satisfy the policy without broadening the allowlist

## Validation
- workflow YAML parse check
- rg check for unpinned uses references
- git diff --check

## Notes
- This is not primarily an allowlist problem; the failing reference is nested inside the older composite action version.
