### PR TITLE
[codex] Use semver comments for pinned action digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "dependencyDashboard": true,
   "minimumReleaseAge": "7 days",


### PR DESCRIPTION
## Summary
- Switch Renovate from helpers:pinGitHubActionDigests to helpers:pinGitHubActionDigestsToSemver
- Keep the existing 7 day cooldown, dashboard approval for majors, and grouping rules

## Why
- Renovate PR #27 pinned GitHub Actions to full SHAs but left major comments like # v6
- zizmor warns when the comment ref no longer resolves to the pinned SHA
- The SemVer helper should generate exact version comments such as # v6.0.2, which matches cooldown-selected releases

## Validation
- mise exec -- npx --yes --package renovate renovate-config-validator renovate.json
- mise exec -- npx --yes --package renovate renovate --platform=local --dry-run=lookup