### PR TITLE
[codex] Use GitHub CLI for release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          files: dist/*
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" dist/* --generate-notes --title "$GITHUB_REF_NAME" --verify-tag


### PR DESCRIPTION
## Summary
- Replace softprops/action-gh-release with gh release create in the release workflow
- Keep generated release notes and dist asset uploads
- Add --verify-tag so tag-triggered releases fail if the remote tag is missing

## Why
The repository action policy allows only K-Oxon-owned, GitHub-created, or verified Marketplace actions, plus full SHA pinning. softprops/action-gh-release was pinned but is not allowed by that policy, so the release workflow was blocked before the step could run.

## Validation
- uvx zizmor --min-severity=low --format=json .github/workflows/release.yml
- gh release create --help