### PR TITLE
[codex] Specify repository for GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,4 +108,4 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "$GITHUB_REF_NAME" dist/* --generate-notes --title "$GITHUB_REF_NAME" --verify-tag
+        run: gh release create "$GITHUB_REF_NAME" dist/* --repo "$GITHUB_REPOSITORY" --generate-notes --title "$GITHUB_REF_NAME" --verify-tag


### PR DESCRIPTION
## Summary
- Pass --repo "" to gh release create in the release workflow

## Why
The publish job does not checkout the repository, so gh cannot infer the repository from .git. The v0.3.1 workflow published to PyPI successfully, then failed while creating the GitHub Release with: fatal: not a git repository.

## Recovery
- Downloaded the v0.3.1 dist artifact from the failed release run
- Created the missing GitHub Release v0.3.1 with the wheel and sdist assets
- Verified the uploaded asset digests match the PyPI 0.3.1 files

## Validation
- uvx zizmor --min-severity=low --format=json .github/workflows/release.yml